### PR TITLE
fix: allow OPERATORS_UAMIS_SUFFIX_FILE path override

### DIFF
--- a/scripts/aro-hcp/gen.sh
+++ b/scripts/aro-hcp/gen.sh
@@ -106,7 +106,7 @@ if [ "$USE_CI" != "true" ] ; then
 fi
 
 
-OPERATORS_UAMIS_SUFFIX_FILE=operators-uamis-suffix.txt
+OPERATORS_UAMIS_SUFFIX_FILE="${OPERATORS_UAMIS_SUFFIX_FILE:-operators-uamis-suffix.txt}"
 if [ ! -f "$OPERATORS_UAMIS_SUFFIX_FILE" ] ; then
     openssl rand -hex 3 > "$OPERATORS_UAMIS_SUFFIX_FILE"
 fi


### PR DESCRIPTION
## Summary
- Make `OPERATORS_UAMIS_SUFFIX_FILE` path overridable via environment variable
- Defaults to `operators-uamis-suffix.txt` (no behavior change for existing users)
- Fixes CI failure where the script writes to a read-only working directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)